### PR TITLE
v1.7b release: improved startLevelChange behavior

### DIFF
--- a/drivers/cocohue-group-driver.groovy
+++ b/drivers/cocohue-group-driver.groovy
@@ -14,7 +14,7 @@
  *
  * =======================================================================================
  *
- *  Last modified: 2019-12-27
+ *  Last modified: 2019-12-29
  * 
  *  Changelog:
  * 
@@ -24,6 +24,8 @@
  *  v1.5b - Eliminated duplicate color/CT events on refresh
  *  v1.6b - Changed bri_inc to match Hubitat behavior
  *  v1.7 - Bulb switch/level states now propgate to groups w/o polling (TODO: add option to disable both?)
+ *  v1.7b - Modified startLevelChange behavior to avoid possible problems with third-party devices
+ *
  *
  */ 
 
@@ -130,7 +132,7 @@ def off() {
 
 def startLevelChange(direction) {
     logDebug("Running startLevelChange($direction)...")
-    def cmd = ["bri_inc": (direction == "up" ? 254 : -254), "transitiontime": 30]
+    def cmd = ["bri": (direction == "up" ? 254 : 1), "transitiontime": 30]
     sendBridgeCommand(cmd, false) 
 }
 

--- a/drivers/cocohue-rgbw-bulb-driver.groovy
+++ b/drivers/cocohue-rgbw-bulb-driver.groovy
@@ -14,7 +14,7 @@
  *
  * =======================================================================================
  *
- *  Last modified: 2019-12-27
+ *  Last modified: 2019-12-29
  * 
  *  Changelog:
  * 
@@ -24,6 +24,7 @@
  *  v1.6 - Eliminated duplicate color/CT events on refresh
  *  v1.6b - Changed bri_inc to match Hubitat behavior
  *  v1.7 - Bulb switch/level states now propgate to groups w/o polling (TODO: add option to disable both?)
+ *  v1.7b - Modified startLevelChange behavior to avoid possible problems with third-party devices
  */ 
 
 import groovy.json.JsonSlurper
@@ -129,7 +130,7 @@ def off() {
 
 def startLevelChange(direction) {
     logDebug("Running startLevelChange($direction)...")
-    def cmd = ["bri_inc": (direction == "up" ? 254 : -254), "transitiontime": 30]
+    def cmd = ["bri": (direction == "up" ? 254 : 1), "transitiontime": 30]
     sendBridgeCommand(cmd, false) 
 }
 


### PR DESCRIPTION
Modified startLevelChange on bulb and group drivers to use bri: 1 or bri: 254 instead of bri_inc to avoid oddities